### PR TITLE
PLDI-355: Default Branch management and branch protection

### DIFF
--- a/Functions/Deploy-GomRepo.ps1
+++ b/Functions/Deploy-GomRepo.ps1
@@ -28,13 +28,104 @@ function Deploy-GomRepo {
 
     $ExistingRepo = Get-GitHubRepository -OwnerName $OrganizationName -RepositoryName $RepoName -ErrorAction SilentlyContinue
 
-    if($null -eq $ExistingRepo){
+    # Create the repository if it doesn't exist
+    if($null -eq $ExistingRepo){        
         Write-Host "Deploying NEW repository '$RepoName' to organization '$OrganizationName'."
-        New-GitHubRepository -OrganizationName $OrganizationName -RepositoryName $RepoName | Format-List
+        $ExistingRepo = New-GitHubRepository -OrganizationName $OrganizationName -RepositoryName $RepoName -AutoInit $true
+    }
+    
+    # Make sure the repo has the desired default branch
+    $DesiredDefaultBranch = $RepoConfig.DefaultBranch
+    $CurrentDefaultBranch = $ExistingRepo.default_branch
+    $OriginalDefaultBranch = $CurrentDefaultBranch
+    if ($DesiredDefaultBranch -and $CurrentDefaultBranch -ne $DesiredDefaultBranch ){
+        Write-Verbose "Default branch on repo '$RepoName' doesn't match the desired default branch from the config, updates will be made..."
+        
+        # Make sure the desired default branch actually exists first
+        try{
+            Write-Verbose "Checking if branch '$DesiredDefaultBranch' exists already on repo '$RepoName'..."
+            Get-GitHubRepositoryBranch -OwnerName $OrganizationName -RepositoryName $RepoName -BranchName $DesiredDefaultBranch | Out-Null
+            Write-Verbose "Branch '$DesiredDefaultBranch' exists."
+        }
+        catch [Microsoft.PowerShell.Commands.HttpResponseException]{
+            Write-Verbose "Branch '$DesiredDefaultBranch' doesn't exist yet on repo '$RepoName', creating..."
+            New-GitHubBranch -OwnerName $OrganizationName -RepositoryName $RepoName -TargetBranchName $DesiredDefaultBranch -BranchName $CurrentDefaultBranch | Out-Null
+            Write-Verbose "Successfully created branch '$DesiredDefaultBranch' on repo '$RepoName'."
+        }
+
+        # Then update the default branch on the repo
+        Write-Verbose "Updating default branch on repo '$RepoName' from '$CurrentDefaultBranch' to '$DesiredDefaultBranch'..."
+        $UpdateDefaultBranch = @{
+            UriFragment = "/repos/$OrganizationName/$RepoName"
+            Method = "Patch"
+            Body = @{
+                default_branch = $DesiredDefaultBranch
+            } | ConvertTo-Json
+        }
+        Invoke-GHRestMethod @UpdateDefaultBranch | Out-Null
+        Write-Verbose "Successfully updated default branch on repo '$RepoName' from '$CurrentDefaultBranch' to '$DesiredDefaultBranch'."
+        $CurrentDefaultBranch = $DesiredDefaultBranch
     }
 
+    # Make sure branch protection is set correctly
+    if($null -ne $RepoConfig.DefaultBranchIsProtected){
+        Write-Verbose "Fetching current branch protection status for branch '$CurrentDefaultBranch' in repo '$RepoName'..."
+        try{
+            Get-GitHubRepositoryBranchProtectionRule -OwnerName $OrganizationName -RepositoryName $RepoName -BranchName $CurrentDefaultBranch | Out-Null
+            Write-Verbose "Branch '$CurrentDefaultBranch' IS currently protected."
+            $DefaultBranchCurrentlyProtected = $true
+        }
+        catch [Microsoft.PowerShell.Commands.HttpResponseException]{
+            Write-Verbose "Branch '$CurrentDefaultBranch' IS NOT currently protected."
+            $DefaultBranchCurrentlyProtected = $false
+        }
+        # If the default branch has changed, lets remove the old protection rule
+        if($CurrentDefaultBranch -ne $OriginalDefaultBranch){
+            try{
+                Write-Verbose "Checking for existing branch protection rule on old default branch '$OriginalDefaultBranch'..."
+                Get-GitHubRepositoryBranchProtectionRule -OwnerName $OrganizationName -RepositoryName $RepoName -BranchName $OriginalDefaultBranch | Out-Null
+                $OldDefaultBranchHasProtectionRule = $true
+                Write-Verbose "Found existing protection rule for branch '$OriginalDefaultBranch'."
+            }
+            catch [Microsoft.PowerShell.Commands.HttpResponseException]{
+                $OldDefaultBranchHasProtectionRule = $false
+                Write-Verbose "No existing protection rule for old default branch '$OriginalDefaultBranch' found."
+            }
+            if($OldDefaultBranchHasProtectionRule -eq $true){
+                Write-Warning "Removing branch protection rule for old default branch '$OriginalDefaultBranch' on repo '$RepoName'..."
+                Remove-GitHubRepositoryBranchProtectionRule -OwnerName $OrganizationName -RepositoryName $RepoName -BranchName $OriginalDefaultBranch -Force | Out-Null
+                Write-Verbose "Successfully removed branch protection for old default branch '$OriginalDefaultBranch' on repo '$RepoName'."
+            }
+        }
+        
+        if(-not $DefaultBranchCurrentlyProtected -and $RepoConfig.DefaultBranchIsProtected -eq $true){
+            Write-Verbose "Configuring branch protection rule on repo '$RepoName' for branch '$CurrentDefaultBranch'..."
+            New-GitHubRepositoryBranchProtectionRule `
+                -OwnerName $OrganizationName `
+                -RepositoryName $RepoName `
+                -BranchName $CurrentDefaultBranch `
+                -DismissStaleReviews `
+                -RequireCodeOwnerReviews `
+                -RequireUpToDateBranches `
+                -RequiredApprovingReviewCount 1
+                | Out-Null
+            Write-Verbose "Sucessfully added branch protection on repo '$RepoName' for branch '$CurrentDefaultBranch'."
+        }
+        elseif ($DefaultBranchCurrentlyProtected -eq $true -and $RepoConfig.DefaultBranchIsProtected -eq $false) {
+            Write-Warning "Removing branch protection for branch '$CurrentDefaultBranch' on repo '$RepoName'..."
+            Remove-GitHubRepositoryBranchProtectionRule -OwnerName $OrganizationName -RepositoryName $RepoName -BranchName $CurrentDefaultBranch -Force | Out-Null
+            Write-Verbose "Successfully removed branch protection on repo '$RepoName' for branch '$CurrentDefaultBranch'."
+        }
+        else{
+            Write-Verbose "No branch protection changes needed for repo '$RepoName'."
+        }
+    }
+
+    # Configure CODEOWNERS for the repository
     if($RepoConfig.CodeOwners){
-        $ExistingContent = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($(Get-GithubContent -Path $CodeOwnersPath -RepositoryName $RepoName -OwnerName $OrganizationName).content))
+        try{$ExistingContent = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($(Get-GithubContent -Path $CodeOwnersPath -RepositoryName $RepoName -OwnerName $OrganizationName).content))}
+        catch{$ExistingContent = ""}
+        
         $CodeOwnersContent = ""
         foreach ($property in $($RepoConfig.CodeOwners | Get-Member -MemberType Properties)){
             $path = $property.Name
@@ -46,7 +137,7 @@ function Deploy-GomRepo {
         if($ExistingContent -ne $CodeOwnersContent){
             $TempBranchName = "codeowners-$(Get-Date -Format FileDateTime)"
             Write-Verbose "Creating new branch '$TempBranchName' in repo '$RepoName' for CODEOWNERS changes."
-            New-GitHubBranch -BranchName $ExistingRepo.default_branch -TargetBranchName $TempBranchName -RepositoryName $RepoName -OwnerName $OrganizationName | Out-Null
+            New-GitHubBranch -BranchName $CurrentDefaultBranch -TargetBranchName $TempBranchName -RepositoryName $RepoName -OwnerName $OrganizationName | Out-Null
             Write-Verbose "Successfully created branch '$TempBranchName' in repo '$RepoName'."
 
             Write-Verbose "Writing new CODEOWNERS file to branch '$TempBranchName' in repo '$RepoName'."
@@ -62,7 +153,6 @@ function Deploy-GomRepo {
             Write-Verbose "Successfully created PR: $($PullRequest.html_url)"
         }
         else{Write-Verbose "CODEOWNERS content matches, no commits made to repo '$RepoName'."}
-        
     }
     
     $ExistingPermissions = Invoke-GHRestMethod -UriFragment "repos/$OrganizationName/$RepoName/teams" -Method Get

--- a/Functions/Export-GomRepo.ps1
+++ b/Functions/Export-GomRepo.ps1
@@ -17,7 +17,7 @@ function Export-GomRepo {
         $ExistingRepo = $_
         $repoName = $ExistingRepo.name
         Write-Verbose "Starting export for repo '$repoName'."
-        $JSONConfigFilePath = "$RepoBaseDirectory/Repos/${repoName}.json"
+        $JSONConfigFilePath = "$RepoBaseDirectory/Repos/$repoName.json"
         $teams = @{}
         $permissions = Invoke-GHRestMethod -UriFragment "repos/$OrganizationName/$repoName/teams" -Method Get
 
@@ -78,9 +78,8 @@ function Export-GomRepo {
             $repo | Add-Member -MemberType NoteProperty -Name CodeOwners -Value $codeOwnersJson
         }
         
-        try{$existingJSONContent = Get-Content -Path $JSONConfigFilePath -ErrorAction Stop}
+        try{$existingJSONContent = Get-Content -Path $JSONConfigFilePath -ErrorAction Stop | ConvertFrom-Json | ConvertTo-Json -Depth 10}
         catch{$existingJSONContent = @{}}
-
         if(Compare-Object $existingJSONContent $($repo | ConvertTo-Json)){
             $repo | ConvertTo-Json -Depth 5 | Set-Content $JSONConfigFilePath
             Write-Host "Updated config file for repo '$repoName'."

--- a/Functions/Sync-GomRepositoryTeamPermission.ps1
+++ b/Functions/Sync-GomRepositoryTeamPermission.ps1
@@ -55,11 +55,13 @@ function Sync-GomRepositoryTeamPermission {
     $ExistingPermissions | Where-Object {
         $_.name -NotIn $JoinedPermissions.TeamName
     } | ForEach-Object {
-        $JoinedPermissions += [PSCustomObject]@{
-            TeamName = $_.name
-            TeamRole = $null
-            Action = 'DELETE_TEAM'
-            PreviousRole = $ExistingTeam.permission
+        if($_.name){
+            $JoinedPermissions += [PSCustomObject]@{
+                TeamName = $_.name
+                TeamRole = $null
+                Action = 'DELETE_TEAM'
+                PreviousRole = $ExistingTeam.permission
+            }
         }
     }
 
@@ -96,7 +98,8 @@ function Sync-GomRepositoryTeamPermission {
                 Remove-GitHubRepositoryTeamPermission `
                     -OwnerName $OrganizationName `
                     -RepositoryName $RepoName `
-                    -TeamName $TeamName
+                    -TeamName $TeamName `
+                    -Force
             }
         }
     }


### PR DESCRIPTION
Added functionality for creating and exporting branch protection on default branches.

Output from changing DefaultBranchIsProtected from false to true:

> PS C:\Users\brett.swan\repos\poc-perms> Deploy-GomRepo -RepoName BrettSwan.TestCreate -verbose
> VERBOSE: Fetching current branch protection status for branch 'foo' in repo 'BrettSwan.TestCreate'...
> VERBOSE: Branch 'foo' IS NOT currently protected.
> VERBOSE: Configuring branch protection rule on repo 'BrettSwan.TestCreate' for branch 'foo'...
> Added branch protection on repo 'BrettSwan.TestCreate' for branch 'foo'.
> VERBOSE: Complete CODEOWNERS content for repo 'BrettSwan.TestCreate' is * @brett-swan-sh
> readme.md @stubhub-migration-poc/DevOps
> VERBOSE: CODEOWNERS content matches, no commits made to repo 'BrettSwan.TestCreate'.
> VERBOSE: Synchronizing permissions for repo 'BrettSwan.TestCreate'.
> VERBOSE: Config matches deployment for Team 'DevOps' with role 'admin' in repo 'BrettSwan.TestCreate'.

Output from changing DefaultBranch from foo to main:

> PS C:\Users\brett.swan\repos\poc-perms> Deploy-GomRepo -RepoName BrettSwan.TestCreate -verbose
> VERBOSE: Fetching current branch protection status for branch 'foo' in repo 'BrettSwan.TestCreate'...
> VERBOSE: Branch 'foo' IS NOT currently protected.
> VERBOSE: Configuring branch protection rule on repo 'BrettSwan.TestCreate' for branch 'foo'...
> Added branch protection on repo 'BrettSwan.TestCreate' for branch 'foo'.
> VERBOSE: Complete CODEOWNERS content for repo 'BrettSwan.TestCreate' is * @brett-swan-sh
> readme.md @stubhub-migration-poc/DevOps
> VERBOSE: CODEOWNERS content matches, no commits made to repo 'BrettSwan.TestCreate'.
> VERBOSE: Synchronizing permissions for repo 'BrettSwan.TestCreate'.
> VERBOSE: Config matches deployment for Team 'DevOps' with role 'admin' in repo 'BrettSwan.TestCreate'.